### PR TITLE
fix(build): resolve spotless config from project dir

### DIFF
--- a/gradle/scripts/spotless.gradle
+++ b/gradle/scripts/spotless.gradle
@@ -15,8 +15,8 @@ spotless {
     java {
         target 'src/main/java/**/*.java', 'src/test/java/**/*.java'
 
-        def orderFile = file("$rootDir/spotless/spotless.importorder")
-        def formatFile = file("$rootDir/spotless/spotless.eclipseformat.xml")
+        def orderFile = file("$projectDir/spotless/spotless.importorder")
+        def formatFile = file("$projectDir/spotless/spotless.eclipseformat.xml")
 
         toggleOffOn()
         importOrderFile(orderFile)
@@ -26,7 +26,7 @@ spotless {
     }
     kotlin {
         target 'src/test/java/**/*.kt'
-        ktlint('1.4.1').setEditorConfigPath("$rootDir/spotless/spotless.ktlint")
+        ktlint('1.4.1').setEditorConfigPath("$projectDir/spotless/spotless.ktlint")
 
         toggleOffOn()
         endWithNewline()


### PR DESCRIPTION
Uses the submodule-local spotless config in multi-project builds so rootDir does not need a duplicate spotless directory.