### PR TITLE
fix(gametest): make ender item link cover test required and assert stored amount

### DIFF
--- a/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
@@ -51,8 +51,8 @@ public class EnderCoversTest {
         });
     }
 
-    @GameTest(template = "empty_5x5", batch = "coverTests", required = false)
-    public static void only_works_in_game_itemLinkCoverTest(GameTestHelper helper) {
+    @GameTest(template = "empty_5x5", batch = "coverTests")
+    public static void itemLinkCoverTest(GameTestHelper helper) {
         QuantumChestMachine chest1 = (QuantumChestMachine) TestUtils.setMachine(helper, new BlockPos(1, 1, 1),
                 GTMachines.SUPER_CHEST[1]);
         QuantumChestMachine chest2 = (QuantumChestMachine) TestUtils.setMachine(helper, new BlockPos(1, 1, 3),
@@ -63,9 +63,11 @@ public class EnderCoversTest {
                 GTItems.COVER_ENDER_ITEM_LINK.asStack(), Direction.UP);
         cover1.setIo(IO.IN);
         cover2.setIo(IO.OUT);
-        chest1.getItemHandlerCap(Direction.UP, false).insertItem(0, new ItemStack(Items.DIAMOND, 64), false);
+        ItemStack stack = new ItemStack(Items.DIAMOND, 64);
+        chest1.getItemHandlerCap(Direction.UP, false).insertItem(0, stack, false);
         helper.runAtTickTime(20, () -> {
-            helper.assertTrue(TestUtils.isItemStackEqual(chest2.getStored(), new ItemStack(Items.DIAMOND, 64)),
+            helper.assertTrue(
+                    ItemStack.isSameItem(chest2.getStored(), stack) && chest2.getStoredAmount() == stack.getCount(),
                     "ender item link cover didn't transfer items");
             helper.succeed();
         });


### PR DESCRIPTION
Matches the fix in CTNH-Modules: QuantumChest stores a single representative item plus a storedAmount, so the test must assert storedAmount instead of the representative stack count.