### PR TITLE
fix(publishing): enable Maven publishing, stop CurseForge task always failing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ apply from: "$projectDir/gradle/scripts/moddevgradle.gradle"
 apply from: "$projectDir/gradle/scripts/repositories.gradle"
 apply from: "$projectDir/dependencies.gradle"
 apply from: "$projectDir/gradle/scripts/resources.gradle"
-//apply from: "$projectDir/gradle/scripts/publishing.gradle"
+apply from: "$projectDir/gradle/scripts/publishing.gradle"
 apply from: "$projectDir/gradle/scripts/spotless.gradle"
 apply from: "$projectDir/gradle/scripts/docs.gradle"
 

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -23,22 +23,41 @@ publishing {
     }
 }
 
-curseforge {
-    apiKey = project.findProperty("curseApiKey") ?: System.getenv("CURSEFORGE_TOKEN")
+// CurseForge upload is only wired up when a token is actually present. The
+// placeholder project id "000000" would otherwise make `curseforge` a task that
+// looks runnable but always fails, and cursegradle warns on a null apiKey during
+// configuration of every build — including plain `compileJava`.
+def curseToken = project.findProperty("curseApiKey") ?: System.getenv("CURSEFORGE_TOKEN")
+def curseProject = project.findProperty("curseProjectId")
 
-    project {
-        id = project.findProperty("curseProjectId") ?: "000000"
-        releaseType = "release"
-        addGameVersion(project.findProperty("minecraftVersion") ?: "1.20.1")
+if (curseToken && curseProject) {
+    curseforge {
+        apiKey = curseToken
 
-        mainArtifact(tasks.findByName("remapJar") ?: tasks.jar) {
-            displayName = "GTM gregtechceu ${project.findProperty("mod_version") ?: "1.0.0"}"
+        project {
+            id = curseProject
+            releaseType = "release"
+            addGameVersion(project.findProperty("minecraftVersion") ?: "1.20.1")
+
+            mainArtifact(tasks.findByName("reobfJar") ?: tasks.jar) {
+                displayName = "GTM gregtechceu ${project.findProperty("mod_version") ?: "1.0.0"}"
+            }
         }
     }
-}
 
-tasks.register("publishCurseForge") {
-    group = "publishing"
-    description = "Build and upload the mod to CurseForge (syncs to Curse Maven)."
-    dependsOn("build", "curseforge")
+    tasks.register("publishCurseForge") {
+        group = "publishing"
+        description = "Build and upload the mod to CurseForge (syncs to Curse Maven)."
+        dependsOn("build", "curseforge")
+    }
+} else {
+    tasks.register("publishCurseForge") {
+        group = "publishing"
+        description = "Disabled: set -PcurseApiKey/CURSEFORGE_TOKEN and -PcurseProjectId to enable."
+        doLast {
+            throw new GradleException(
+                "CurseForge upload is not configured. Provide CURSEFORGE_TOKEN (or -PcurseApiKey) " +
+                "and -PcurseProjectId=<id> before running publishCurseForge.")
+        }
+    }
 }


### PR DESCRIPTION
﻿## Problem 1: publishing.gradle was never applied

`build.gradle` had

```groovy
//apply from: "$projectDir/gradle/scripts/publishing.gradle"
```

so `:modules:gtm-reborn:publish` reported `UP-TO-DATE` and wrote nothing. Only gtecore ever reached the GitHub Pages Maven repo; gtm-reborn silently published nothing on every CI run. Uncommented.

## Problem 2: the cursegradle block created a task that could only fail

`curseforge { project { id = "000000" ... } }` was configured unconditionally with a placeholder project id, which registers a `publishCurseForge` task that always fails against the real API and emits a warning on every single build.

It is now configured only when a token and a real project id are both present (`curseApiKey`/`CURSEFORGE_TOKEN` and `curseProjectId`). Otherwise a stub `publishCurseForge` is registered that throws a `GradleException` naming the missing property — so asking for it still fails loudly, but merely building no longer warns.

`mainArtifact` also moved from `remapJar` to `reobfJar`: this module has no `remapJar` task, so the reference would not have resolved anyway.

## Verification

Local run with `-PmavenDir` pointed at a scratch directory:

```
com/gregtechceu/gtceu/gtm-reborn-1.20.1/8.3.2/gtm-reborn-1.20.1-8.3.2.jar
com/gregtechceu/gtceu/gtm-reborn-1.20.1/8.3.2/gtm-reborn-1.20.1-8.3.2-slim.jar
com/gregtechceu/gtceu/gtm-reborn-1.20.1/8.3.2/gtm-reborn-1.20.1-8.3.2-sources.jar
com/gregtechceu/gtceu/gtm-reborn-1.20.1/8.3.2/gtm-reborn-1.20.1-8.3.2.pom
com/gregtechceu/gtceu/gtm-reborn-1.20.1/8.3.2/gtm-reborn-1.20.1-8.3.2.module
com/gregtechceu/gtceu/gtm-reborn-1.20.1/maven-metadata.xml
(plus md5/sha1/sha256/sha512 for each)

BUILD SUCCESSFUL
```
