### PR TITLE
chore: align the standalone Forge version with the aggregate build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,16 @@
 [versions]
 minecraft = "1.20.1"
-forge = "47.3.0"
-minecraftForge = "1.20.1-47.3.0"
+# Must match the aggregate build (root gradle/libs.versions.toml), gradle.properties
+# and gte/pack.toml: gtmthings 1.5.4 requires forge "[47.4.1,)", while 47.4.10 ships
+# ASM 9.8 / coremods 5.2.4 and appliedenergistics2 15.4.9's mixins stop resolving
+# there, so 47.4.1 is the only version that satisfies both.
+#
+# This catalog only applies to a standalone build of this repository -- the
+# aggregate build includes this directory through the root settings.gradle, whose
+# catalog wins. It was 47.3.0, which is below gtmthings' floor, so a standalone
+# build compiled against a Forge the shipped pack cannot run on.
+forge = "47.4.1"
+minecraftForge = "1.20.1-47.4.1"
 parchment = "2023.09.03" # https://parchmentmc.org/docs/getting-started
 shadow = "8.3.5"
 spotless = "7.0.2"


### PR DESCRIPTION
## What

This catalog declared `forge = "47.3.0"` / `minecraftForge = "1.20.1-47.3.0"`, which is **below the floor the GTE pack requires**.

The aggregate GTE build includes this directory through the root `settings.gradle`, whose catalog declares 47.4.1, and that catalog wins — so nothing produced by that build was affected. Only a standalone build of this repository compiled against 47.3.0, i.e. against a Forge the shipped pack cannot run on.

## Why 47.4.1 specifically

Not a preference — it is the only version that works:

| | |
|---|---|
| 47.3.0 and below | `gtmthings` 1.5.4 declares `forge "[47.4.1,)"` and refuses to load |
| 47.4.10 | ships ASM 9.8 + coremods 5.2.4; `appliedenergistics2` 15.4.9's mixins stop resolving and the client dies before the main menu |

`gte/pack.toml` and the aggregate catalog both pin it for this reason.

## Scope note

`mods.toml` here interpolates `${forge_version}`, but that value comes from `libs.versions.forge` with **only its major component kept** (`gradle/scripts/resources.gradle` does `.split("\\.")[0]`), so the generated range stays `[47,)` either way. This change affects what the module *compiles against*, not its declared dependency range.

## Verification

- Aggregate build compiles this module (`:modules:gtm-reborn:compileJava`) — exit 0.
- An init-script probe reading the resolved catalog confirms `forge=47.4.1`, `minecraftForge=1.20.1-47.4.1`.

## Not verified: standalone build

Standalone `gradlew` in this repository fails during configuration, before reaching anything this PR touches:

```
Script 'gradle/scripts/repositories.gradle' line: 2
> Could not create an instance of type DefaultScriptHandler.
   > java.lang.StackOverflowError
```

That file is `apply from: "${rootDir}/gradle/scripts/repositories.gradle"` — in the aggregate build `rootDir` is the GTE root and it inherits the shared repository list, but when this repository **is** the root it applies itself and recurses forever. This predates the change and is left for a separate fix.
