### PR TITLE
fix(build): stop repositories.gradle from applying itself in a standalone build

### DIFF
--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -8,6 +8,11 @@ jei = "15.20.0.105"
 rei = "12.1.785"
 emi = "1.1.13+1.20.1"
 ae2 = "15.0.18"
+# guideme is a runtime dependency of AE2 and is referenced by dependencies.gradle
+# (modLocalRuntime(forge.guideme)). It was missing here, so a standalone build of
+# this repository failed with "Could not get unknown property 'guideme'". Kept in
+# sync with the aggregate build's gradle/forge.versions.toml.
+guideme = "20.1.10"
 kubejs = "2001.6.5-build.16"
 rhino = "2001.2.3-build.10"
 architectury = "9.2.14"
@@ -69,6 +74,7 @@ rei-forge           = { module = "me.shedaniel:RoughlyEnoughItems-forge", versio
 emi                 = { module = "dev.emi:emi-forge", version.ref = "emi" }
 
 ae2                 = { module = "appeng:appliedenergistics2-forge", version.ref = "ae2" }
+guideme             = { module = "org.appliedenergistics:guideme", version.ref = "guideme" }
 create              = { module = "com.simibubi.create:create-1.20.1", version.ref = "create"}
 ponder              = { module = "net.createmod.ponder:Ponder-Forge-1.20.1", version.ref = "ponder"}
 flywheel-forge-api  = { module = "dev.engine-room.flywheel:flywheel-forge-api-1.20.1", version.ref = "flywheel"}

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -1,2 +1,25 @@
-// Inherit all repositories from root gradle/scripts/repositories.gradle
-apply from: "${rootDir}/gradle/scripts/repositories.gradle"
+// ============================================================================
+// repositories.gradle — repository wiring for BOTH build layouts
+// ============================================================================
+// In the aggregate GTE build this directory is included by the GTE root's
+// settings.gradle, so `rootDir` points at the GTE root and this file inherits the
+// single shared repository list there.
+//
+// When this repository is built standalone, `rootDir` IS this directory -- so the
+// previous one-line version of this file, `apply from:
+// "${rootDir}/gradle/scripts/repositories.gradle"`, applied *itself* and recursed
+// until the JVM gave up:
+//
+//     Script 'gradle/scripts/repositories.gradle' line: 2
+//     > Could not create an instance of type DefaultScriptHandler.
+//        > java.lang.StackOverflowError
+//
+// The guard below compares canonical paths, so the shared list is inherited when
+// there is one and the local fallback (this repository's own list, as it stood
+// before the shared file was introduced) is used when there is not.
+def shared = file("${rootDir}/gradle/scripts/repositories.gradle")
+if (shared.exists() && shared.canonicalFile != buildscript.sourceFile.canonicalFile) {
+    apply from: shared
+} else {
+    apply from: "${projectDir}/gradle/scripts/repositories.standalone.gradle"
+}

--- a/gradle/scripts/repositories.standalone.gradle
+++ b/gradle/scripts/repositories.standalone.gradle
@@ -1,0 +1,101 @@
+repositories {
+    mavenLocal()
+    mavenCentral()
+    flatDir {
+        dir "${rootDir}/modules/gtecore/gradle/libs"
+    }
+    maven {
+        url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
+        content { includeGroup "fuzs" }
+    }
+    maven { url = "https://maven.createmod.net" }
+    maven { // JEI
+        name = "Jared's Maven"
+        url = "https://maven.blamejared.com/"
+    }
+
+    maven { // JEI mirror, AE2
+        name = "ModMaven"
+        url = "https://modmaven.dev"
+    }
+
+    maven { // LDLib, Shimmer
+        name = "FirstDarkDev Maven"
+        url = "https://maven.firstdark.dev/snapshots"
+    }
+    maven {
+        name = "FirstDarkDev XYZ Maven"
+        url = "https://maven.firstdarkdev.xyz/snapshots"
+    }
+
+    maven { // Configuration (Toma)
+        name = 'Configuration'
+        url = 'https://api.repsy.io/mvn/toma/public/'
+    }
+
+    maven { // TeamResourceful
+        name = 'TeamResourceful'
+        url = 'https://maven.teamresourceful.com/repository/maven-public/'
+    }
+
+    maven {
+        name = 'tterrag'
+        url = "https://maven.tterrag.com/"
+    }
+
+    maven {
+        name = 'Latvian'
+        url = "https://maven.latvian.dev/releases"
+    }
+
+    maven {
+        name = 'FTB'
+        url = "https://maven.ftb.dev/releases"
+    }
+
+    maven {
+        name = 'TOP'
+        url = "https://maven.k-4u.nl"
+    }
+
+    maven {
+        name = 'JourneyMap'
+        url = "https://jm.gserv.me/repository/maven-public/"
+    }
+
+    maven {
+        name = 'Modrinth'
+        url = "https://api.modrinth.com/maven"
+    }
+
+    maven {
+        name = 'CurseMaven'
+        url = "https://cursemaven.com"
+        content { includeGroup "curse.maven" }
+    }
+
+    maven {
+        name = 'Terraformers'
+        url = "https://maven.terraformersmc.com/releases/"
+    }
+
+    maven {
+        name = 'shedaniel'
+        url = "https://maven.shedaniel.me/"
+    }
+
+    maven {
+        name = 'Curios'
+        url = "https://maven.theillusivec4.top/"
+    }
+
+    maven {
+        name = 'KotlinForForge'
+        url = "https://thedarkcolour.github.io/KotlinForForge/"
+    }
+
+    maven {
+        name = 'SquidDev'
+        url = "https://maven.squiddev.cc"
+    }
+}


### PR DESCRIPTION
## The bug

Standalone `gradlew` in this repository died during configuration:

```
Script 'gradle/scripts/repositories.gradle' line: 2
> Could not create an instance of type DefaultScriptHandler.
   > java.lang.StackOverflowError
```

The whole file was one line:

```groovy
apply from: "${rootDir}/gradle/scripts/repositories.gradle"
```

In the aggregate GTE build that is correct — this directory is included by the GTE root's `settings.gradle`, so `rootDir` is the GTE root and the shared 24-repository list is inherited. But when **this** repository is the root, `rootDir` is this directory, so the file applied itself and recursed until the JVM gave up.

Introduced by `build: unify shared repositories and maven publish setup`, which replaced 101 local lines with that one line.

## The fix

Keeps the single-source-of-truth behaviour, adds a canonical-path guard:

```groovy
def shared = file("${rootDir}/gradle/scripts/repositories.gradle")
if (shared.exists() && shared.canonicalFile != buildscript.sourceFile.canonicalFile) {
    apply from: shared
} else {
    apply from: "${projectDir}/gradle/scripts/repositories.standalone.gradle"
}
```

`repositories.standalone.gradle` is this repository's own list, restored verbatim from the commit before the unify — no repositories invented or dropped.

## Second blocker, also fixed

With the recursion gone, the standalone build hit:

```
Script 'dependencies.gradle' line: 79
> Could not get unknown property 'guideme' for extension 'forge'
```

`dependencies.gradle` line 79 is `modLocalRuntime(forge.guideme)`, but the `guideme` key existed only in the aggregate build's `gradle/forge.versions.toml`. Added it here with the version and module coordinate copied exactly from the aggregate catalog (`org.appliedenergistics:guideme:20.1.10`).

For context, this repo's catalog is missing 31 keys the aggregate one has; `guideme` is the only one `dependencies.gradle` actually references, so it is the only one added.

## Verification

- Standalone `gradlew compileJava` → **BUILD SUCCESSFUL in 3m 26s**.
- Aggregate GTE build still compiles all three modules — exit 0.
