### PR TITLE
fix(recipe): multiparallel free EU and chanced output int overflow

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
+import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.ChatFormatting;
@@ -354,7 +355,7 @@ public class MultiblockDisplayText {
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidOutputs = recipe.getOutputContents(FluidRecipeCapability.CAP);
-                int runs = recipe.parallels * recipe.batchParallels;
+                int runs = GTMath.saturatedCast((long) recipe.parallels * recipe.batchParallels);
 
                 for (var item : itemOutputs) {
                     boolean rounded = false;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -18,10 +18,8 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
-import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
-import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.sound.AutoReleasedSound;
 import com.gregtechceu.gtceu.common.cover.MachineControllerCover;
@@ -415,36 +413,23 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
             for (int i = 0; i < machine.getRecipeTypes().length; ++i) {
                 if (!ActiveModesList.get(i)) continue;
                 List<GTRecipe> Recipe_List = new ArrayList<>();
-                int sumOfParallelsCount = 0;
+                // MultiParallelCount is a thread count: how many recipes may run side by side.
+                // Every thread keeps whatever parallels its own recipe modifiers granted it, so
+                // per-recipe parallels must never be charged against this budget.
+                int threadCount = 0;
                 int LoopCount = 0;
                 int FailesCount = 0;
                 while (true) {
                     machine.setActiveRecipeType(i);
-                    if (sumOfParallelsCount >= MultiParallelCount) break;
-                    int remainingParallels = MultiParallelCount - sumOfParallelsCount;
+                    if (threadCount >= MultiParallelCount) break;
 
                     handleSearchingRecipes(searchRecipe());
                     if (lastRecipe == null) break;
 
-                    int recipeParallels = Math.max(1, lastRecipe.parallels);
-                    if (recipeParallels <= 1 && remainingParallels > 1) {
-                        int canParallel = ParallelLogic.getParallelAmount(machine.self(), lastRecipe,
-                                remainingParallels);
-                        if (canParallel > 1) {
-                            lastRecipe = lastRecipe.copy();
-                            lastRecipe.inputs = ContentModifier.multiplier(canParallel)
-                                    .applyContents(lastRecipe.inputs);
-                            lastRecipe.outputs = ContentModifier.multiplier(canParallel)
-                                    .applyContents(lastRecipe.outputs);
-                            lastRecipe.parallels = canParallel;
-                            recipeParallels = canParallel;
-                        }
-                    }
-
                     var handledIO = handleRecipeIO(lastRecipe, IO.IN);
                     if (handledIO.isSuccess()) {
                         Recipe_List.add(lastRecipe);
-                        sumOfParallelsCount += recipeParallels;
+                        threadCount++;
                         lastRecipe = null;
                         lastOriginRecipe = null;
                         lastFailedMatches = null;
@@ -454,7 +439,6 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     if (FailesCount > 2) break;
                     LoopCount++;
                     if (LoopCount > maxLoopCount) break;
-                    if (sumOfParallelsCount >= MultiParallelCount) break;
                 }
                 GTRecipe recipe = mergeAllRecipes(Recipe_List);
                 if (recipe == null) continue;
@@ -530,13 +514,9 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         }
 
         afterMergeRecipe.duration = max(afterMergeRecipe.duration, recipe.duration);
-        afterMergeRecipe.getInputEUt();// Calculate the input EU and the output EU
-        afterMergeRecipe.getOutputEUt();
-        boolean isOutputEU = false;
-        if (afterMergeRecipe.getOutputEUt().getTotalEU() > 0) {
-            isOutputEU = true;
-        }
-        afterMergeRecipe.parallels = afterMergeRecipe.parallels + recipe.parallels;
+        // Do not touch getInputEUt()/getOutputEUt() here: they are Lombok lazy fields, so reading them
+        // before the tick contents below are merged would freeze the pre-merge EU/t for good.
+        afterMergeRecipe.parallels = GTMath.saturatedCast((long) afterMergeRecipe.parallels + recipe.parallels);
         afterMergeRecipe.batchParallels = max(afterMergeRecipe.batchParallels, recipe.batchParallels);
         afterMergeRecipe.inputs = makeValuesMutable(afterMergeRecipe.inputs);
         afterMergeRecipe.outputs = makeValuesMutable(afterMergeRecipe.outputs);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.utils.GTMath;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
@@ -95,7 +96,7 @@ public class RecipeRunner {
             if (!chancedContents.isEmpty()) {
                 var cache = this.chanceCaches.get(cap);
                 chancedContents = logic.roll(chancedContents, function, recipeTier, chanceTier, cache,
-                        recipe.parallels * recipe.batchParallels);
+                        GTMath.saturatedCast((long) recipe.parallels * recipe.batchParallels));
 
                 for (Content cont : chancedContents) {
                     contentList.add(cont.content);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.utils.GTMath;
 
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.fml.ModLoader;
@@ -49,10 +50,12 @@ public abstract class ChanceLogic {
                 // If a large batch is being done we can calculate how many we expect to get.
                 // Add the guaranteed part of that to the list, then roll for the remaining chanced part.
                 int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
-                int totalChance = times * newChance;
-                int guaranteed = totalChance / maxChance;
+                // times can reach hundreds of thousands with parallels and batches, so this product has to
+                // be computed as a long: an int would wrap around and silently swallow the outputs
+                long totalChance = (long) times * newChance;
+                int guaranteed = GTMath.saturatedCast(totalChance / maxChance);
                 if (guaranteed > 0) builder.addAll(Collections.nCopies(guaranteed, entry));
-                newChance = totalChance % maxChance;
+                newChance = (int) (totalChance % maxChance);
 
                 int cached = getCachedChance(entry, cache);
                 int chance = newChance + cached;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
+import com.gregtechceu.gtceu.utils.GTMath;
 
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -165,9 +166,9 @@ public interface ModifierFunction {
                         new HashMap<>(recipe.tickInputChanceLogics), new HashMap<>(recipe.tickOutputChanceLogics),
                         newConditions, new ArrayList<>(recipe.ingredientActions),
                         recipe.data, recipe.duration, recipe.recipeCategory);
-                copied.parallels = recipe.parallels * parallels;
+                copied.parallels = GTMath.saturatedCast((long) recipe.parallels * parallels);
                 copied.ocLevel = recipe.ocLevel + addOCs;
-                copied.batchParallels = recipe.batchParallels * batchParallels;
+                copied.batchParallels = GTMath.saturatedCast((long) recipe.batchParallels * batchParallels);
                 if (recipe.data.getBoolean("duration_is_total_cwu")) {
                     copied.duration = (int) Math.max(1, (recipe.duration * (1f - 0.025f * addOCs)));
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedActivityDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedActivityDetectorCover.java
@@ -24,16 +24,17 @@ public class AdvancedActivityDetectorCover extends ActivityDetectorCover {
             return;
 
         var workable = GTCapabilityHelper.getWorkable(coverHolder.getLevel(), coverHolder.getPos(), attachedSide);
-        if (workable == null || workable.getMaxProgress() == 0)
+        if (workable == null)
             return;
 
-        int outputAmount = RedstoneUtil.computeRedstoneValue(workable.getProgress(), workable.getMaxProgress(),
-                isInverted());
+        // nonstandard logic for handling off state: an idle machine reports no progress at all, so the
+        // signal has to be cleared here instead of keeping the last value of the finished recipe
+        int maxProgress = workable.getMaxProgress();
+        if (maxProgress <= 0 || !workable.isWorkingEnabled() || !workable.isActive()) {
+            setRedstoneSignalOutput(0);
+            return;
+        }
 
-        // nonstandard logic for handling off state
-        if (!workable.isWorkingEnabled() || !workable.isActive())
-            outputAmount = 0;
-
-        setRedstoneSignalOutput(outputAmount);
+        setRedstoneSignalOutput(RedstoneUtil.computeRedstoneValue(workable.getProgress(), maxProgress, isInverted()));
     }
 }

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/chance/ChanceLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/chance/ChanceLogicTest.java
@@ -1,0 +1,73 @@
+package com.gregtechceu.gtceu.api.recipe.chance;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
+import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
+import com.gregtechceu.gtceu.gametest.util.TestUtils;
+
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.gametest.GameTestHolder;
+import net.minecraftforge.gametest.PrefixGameTestTemplate;
+
+import java.util.List;
+
+/**
+ * Chanced outputs are rolled once for a whole recipe run, so the number of rolls is
+ * {@code parallels * batchParallels}. These tests cover the run counts at which that number, and the chance
+ * math derived from it, no longer fit into an int.
+ */
+@PrefixGameTestTemplate(false)
+@GameTestHolder(GTCEu.MOD_ID)
+public class ChanceLogicTest {
+
+    @GameTest(template = "empty_5x5", batch = "chanceLogic")
+    public static void orLogicKeepsChancedOutputsAtHighRunCountTest(GameTestHelper helper) {
+        int maxChance = ChanceLogic.getMaxChancedValue();
+        Content entry = new Content(new ItemStack(Items.DIRT), maxChance / 2, maxChance, 0);
+        // A 50% output rolled a million times is 500k guaranteed outputs with nothing left to roll for.
+        // The intermediate product is 5e9 here: as an int it wrapped around to 70503 outputs instead,
+        // and any batch above ~430k runs of a 50% output was affected.
+        List<Content> rolled = ChanceLogic.OR.roll(List.of(entry), ChanceBoostFunction.NONE, 0, 0, 1_000_000);
+        helper.assertTrue(rolled.size() == 500_000,
+                "expected 500000 chanced outputs, got " + rolled.size());
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty_5x5", batch = "chanceLogic")
+    public static void runCountSaturatesInsteadOfWrappingTest(GameTestHelper helper) {
+        GTRecipeType recipeType = TestUtils.createRecipeType("chance_logic_tests");
+        GTRecipe recipe = recipeType
+                .recipeBuilder(GTCEu.id("test_chance_logic_run_count"))
+                .inputItems(new ItemStack(Items.COBBLESTONE))
+                .outputItems(new ItemStack(Blocks.STONE))
+                .EUt(GTValues.V[GTValues.LV])
+                .duration(20)
+                .buildRawRecipe();
+        recipe.parallels = 1 << 20;
+        recipe.batchParallels = 1 << 20;
+
+        // Both factors are multiplied by the modifier, and 2^20 * 2^12 does not fit into an int: it used to
+        // wrap around to zero (or worse, to a negative count, which drops every chanced output).
+        GTRecipe modified = ModifierFunction.builder()
+                .parallels(1 << 12)
+                .batchParallels(1 << 12)
+                .build()
+                .apply(recipe);
+        helper.assertTrue(modified != null, "modifier cancelled the recipe");
+        assert modified != null;
+        helper.assertTrue(modified.parallels == Integer.MAX_VALUE,
+                "expected saturated parallels, got " + modified.parallels);
+        helper.assertTrue(modified.batchParallels == Integer.MAX_VALUE,
+                "expected saturated batch parallels, got " + modified.batchParallels);
+        helper.succeed();
+    }
+}

--- a/src/test/java/com/gregtechceu/gtceu/common/cover/AdvancedDetectorCoverTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/AdvancedDetectorCoverTest.java
@@ -1,8 +1,10 @@
 package com.gregtechceu.gtceu.common.cover;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.common.cover.detector.AdvancedFluidDetectorCover;
 import com.gregtechceu.gtceu.common.cover.detector.AdvancedItemDetectorCover;
 import com.gregtechceu.gtceu.common.data.GTItems;
@@ -14,6 +16,7 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
@@ -27,28 +30,47 @@ import net.minecraftforge.gametest.PrefixGameTestTemplate;
 @GameTestHolder(GTCEu.MOD_ID)
 public class AdvancedDetectorCoverTest {
 
-    @GameTest(template = "electrolyzer", batch = "coverTests", required = false)
-    public static void BLOCKED_BY_LDLIB_WEIRDNESS_PROBABLY_testAdvancedActivityDetectorCover(GameTestHelper helper) {
+    @GameTest(template = "electrolyzer", batch = "coverTests")
+    public static void testAdvancedActivityDetectorCover(GameTestHelper helper) {
         helper.pullLever(new BlockPos(2, 2, 2));
         MetaMachine machine = ((IMachineBlockEntity) helper.getBlockEntity(new BlockPos(1, 2, 1))).getMetaMachine();
+        // The template's electrolyzer is UEV, which overclocks water electrolysis down to a couple of ticks,
+        // making progress (and with it this cover's output) flicker between 0 and 15. Pinning the overclock
+        // tier to LV keeps the recipe at its base duration so the reported progress is stable.
+        ((IOverclockMachine) machine).setOverclockTier(GTValues.LV);
         TestUtils.placeCover(helper, machine, GTItems.COVER_ACTIVITY_DETECTOR_ADVANCED.asStack(), Direction.WEST);
-        helper.runAtTickTime(30, () -> helper.assertRedstoneSignal(
+        // Minecraft asks a block for its signal from the opposite side (see MetaMachine#getOutputSignal),
+        // so the cover attached to WEST answers a query for Direction.EAST.
+        // The cover only refreshes every 20 ticks, so wait for the signal instead of probing a fixed tick.
+        helper.succeedWhen(() -> helper.assertRedstoneSignal(
                 new BlockPos(1, 2, 1),
-                Direction.WEST,
+                Direction.EAST,
                 signal -> signal > 0,
                 () -> "expected redstone signal"));
     }
 
-    @GameTest(template = "electrolyzer", batch = "coverTests", required = false)
-    public static void BLOCKED_BY_LDLIB_WEIRDNESS_TOO_PROBABLY_testAdvancedActivityDetectorCover(GameTestHelper helper) {
+    @GameTest(template = "electrolyzer", batch = "coverTests", timeoutTicks = 200)
+    public static void testAdvancedActivityDetectorCoverGoesOffWhenIdle(GameTestHelper helper) {
         helper.pullLever(new BlockPos(2, 2, 2));
         MetaMachine machine = ((IMachineBlockEntity) helper.getBlockEntity(new BlockPos(1, 2, 1))).getMetaMachine();
+        // ZPM keeps water electrolysis at 23 ticks: long enough that the cover's 20 tick sampling sees
+        // progress instead of only catching the tick a recipe starts on, short enough for the machine to
+        // reach the end of its recipe - and with it idle - inside the test.
+        ((IOverclockMachine) machine).setOverclockTier(GTValues.ZPM);
         TestUtils.placeCover(helper, machine, GTItems.COVER_ACTIVITY_DETECTOR_ADVANCED.asStack(), Direction.WEST);
-        helper.runAtTickTime(35, () -> helper.pullLever(2, 2, 2));
-        helper.runAtTickTime(40, () -> {
-            TestUtils.assertLampOff(helper, new BlockPos(0, 2, 1));
-            helper.succeed();
-        });
+        helper.startSequence()
+                .thenWaitUntil(() -> TestUtils.assertLampOn(helper, new BlockPos(0, 2, 1)))
+                // Cut the water supply and drop the buffered water, so the machine falls back to idle
+                // instead of chewing through the water it already pulled in.
+                .thenExecute(() -> {
+                    helper.pullLever(2, 2, 2);
+                    var tanks = machine.getFluidHandlerCap(null, false);
+                    for (int i = 0; i < tanks.getTanks(); i++) {
+                        tanks.setFluidInTank(i, FluidStack.EMPTY);
+                    }
+                })
+                .thenWaitUntil(() -> TestUtils.assertLampOff(helper, new BlockPos(0, 2, 1)))
+                .thenSucceed();
     }
 
     @GameTest(template = "electrolyzer", batch = "coverTests")

--- a/src/test/java/com/gregtechceu/gtceu/common/cover/SolarPanelTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/SolarPanelTest.java
@@ -17,45 +17,63 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
+/**
+ * Solar panel covers need real sky access, which the templates cannot provide: the automated game test
+ * server generates an ordinary overworld and lays every test out far underground, so sky light never
+ * reaches a machine standing inside the structure. Both tests therefore build their machine in open air
+ * high above their own test area and pin the weather, which keeps them independent of the terrain.
+ */
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class SolarPanelTest {
 
+    private static final int OPEN_SKY_Y = 300;
+
     private static BatteryBufferMachine makeBatteryBuffer(GameTestHelper helper, int tier) {
-        helper.setBlock(new BlockPos(0, 1, 0), GTMachines.BATTERY_BUFFER_4[tier].getBlock());
-        return (BatteryBufferMachine) ((MetaMachineBlockEntity) helper.getBlockEntity(new BlockPos(0, 1, 0)))
-                .getMetaMachine();
+        var level = helper.getLevel();
+        // rain and thunder also hide the sun, and the test world's weather is not deterministic
+        level.setWeatherParameters(24000, 0, false, false);
+        BlockPos anchor = helper.absolutePos(new BlockPos(2, 1, 2));
+        BlockPos pos = new BlockPos(anchor.getX(), OPEN_SKY_Y, anchor.getZ());
+        // Only the structure itself is cleaned up between runs, so clear this spot first: setting the same
+        // machine block again would keep the old block entity, together with its covers and stored energy.
+        BlockPos.betweenClosed(pos.offset(-1, -1, -1), pos.offset(1, 1, 1))
+                .forEach(p -> level.setBlockAndUpdate(p.immutable(), Blocks.AIR.defaultBlockState()));
+        level.setBlockAndUpdate(pos, GTMachines.BATTERY_BUFFER_4[tier].getBlock().defaultBlockState());
+        return (BatteryBufferMachine) ((MetaMachineBlockEntity) level.getBlockEntity(pos)).getMetaMachine();
     }
 
     private static void placeSolar(GameTestHelper helper, MetaMachine machine) {
         TestUtils.placeCover(helper, machine, GTItems.COVER_SOLAR_PANEL_HV.asStack(), Direction.UP);
     }
 
-    @GameTest(template = "empty_5x5", batch = "coverTests", required = false) // it doesn't fail only if running tests
-                                                                              // with the command for some reason
-    public static void only_works_in_game_generatesEnergyAtDayTest(GameTestHelper helper) {
+    @GameTest(template = "empty_5x5", batch = "coverTests")
+    public static void generatesEnergyAtDayTest(GameTestHelper helper) {
         helper.setDayTime(6000);
         BatteryBufferMachine machine = makeBatteryBuffer(helper, GTValues.HV);
         machine.getBatteryInventory().insertItem(0, GTItems.BATTERY_HV_LITHIUM.asStack(), false);
         placeSolar(helper, machine);
-        helper.runAtTickTime(80, () -> {
-            helper.assertTrue(machine.energyContainer.getEnergyStored() > 0,
-                    "Solar panel cover didn't generate energy at day time");
-            helper.succeed();
-        });
+        // the sky light of the freshly placed machine is only known once the light engine caught up
+        helper.succeedWhen(() -> helper.assertTrue(machine.energyContainer.getEnergyStored() > 0,
+                "Solar panel cover didn't generate energy at day time"));
     }
 
     @GameTest(template = "empty_5x5", batch = "coverTests")
     public static void doesntGenerateEnergyAtDayWhenBlockedTest(GameTestHelper helper) {
         helper.setDayTime(6000);
         BatteryBufferMachine machine = makeBatteryBuffer(helper, GTValues.HV);
-        helper.setBlock(new BlockPos(0, 3, 0), Blocks.DIAMOND_BLOCK);
+        var level = helper.getLevel();
+        BlockPos above = machine.getPos().above();
+        level.setBlockAndUpdate(above.above(), Blocks.DIAMOND_BLOCK.defaultBlockState());
         machine.getBatteryInventory().insertItem(0, GTItems.BATTERY_HV_LITHIUM.asStack(), false);
-        placeSolar(helper, machine);
-        helper.runAtTickTime(40, () -> {
-            helper.assertTrue(machine.energyContainer.getEnergyStored() == 0,
-                    "Solar panel cover generated energy when blocked");
-            helper.succeed();
-        });
+        helper.startSequence()
+                // blocks placed at runtime leave the light engine a tick behind, so only cover the machine
+                // once the sky above it really is blocked - a battery keeps what leaked in before that
+                .thenWaitUntil(
+                        () -> helper.assertTrue(!level.canSeeSky(above), "sky above the machine is not blocked yet"))
+                .thenExecute(() -> placeSolar(helper, machine))
+                .thenExecuteAfter(40, () -> helper.assertTrue(machine.energyContainer.getEnergyStored() == 0,
+                        "Solar panel cover generated energy when blocked"))
+                .thenSucceed();
     }
 }


### PR DESCRIPTION
## Summary

Three related correctness fixes plus the three cover game tests that were disabled with `required = false`.

### Multiparallel (thread) merging — `RecipeLogic`

* The intra-recipe parallel block in the multiparallel loop scaled only `inputs` / `outputs`. EU/t and tick fluids stayed at 1x, so a machine could do up to `MultiParallelCount` times the work for a single recipe's cost. `MultiParallelCount` is a thread count and every thread already pays for its own recipe, so the block is removed and the budget counts threads.
* `mergeTwoRecipes` primed the Lombok lazy `getInputEUt()` / `getOutputEUt()` fields *before* the tick contents were merged, which cached the first thread's EU/t forever — the merged recipe then billed one thread's power for all of them.
* Merged `parallels` are summed with saturation instead of wrapping.

### Chanced outputs

* `ChanceLogic.OR` computed `times * chance` as an `int`. Chanced outputs are rolled once per run batch, so `times = parallels * batchParallels`; above ~430k runs of a 50% output the product wrapped around and silently dropped most of the outputs (1M runs produced 70504 instead of 500000).
* The roll count itself (`RecipeRunner`) and the parallel counts in `ModifierFunction` are saturating now, so they can no longer wrap to zero or to a negative count — a negative count makes `AND` / `FIRST` / `XOR` skip every roll. `MultiblockDisplayText` uses the same saturating product for its output rate line.

Known remaining limitation: `OR` still materialises the guaranteed part as one list entry per produced unit, so an absurd parallel count (the 1e9 caps some addon machines use) with chanced outputs can exhaust memory. Fixing that means scaling a single `Content` instead, which needs the capability inside `ChanceLogic#roll` and changes how outputs are inserted, so it is left out of this PR.

### `AdvancedActivityDetectorCover`

Once a machine went idle, `RecipeLogic` cleared progress and duration, the cover returned early on `maxProgress == 0` and kept its last signal forever — a stopped machine reported activity indefinitely. It now clears the output in that case.

## Tests

`:modules:gtm-reborn:runGameTestServer` — all 100 required tests pass. The three previously optional tests are required now:

* `testAdvancedActivityDetectorCover` and `testAdvancedActivityDetectorCoverGoesOffWhenIdle`: the template's electrolyzer is UEV, which overclocks water electrolysis down to ~2 ticks, so the cover's 20 tick sampling caught `progress == 0` at random. Both tests pin the overclock tier, which keeps the reported progress stable. The idle test fails without the cover fix (lamp stays lit for 200 ticks).
* `generatesEnergyAtDayTest` / `doesntGenerateEnergyAtDayWhenBlockedTest`: the automated test server generates a normal overworld and places every structure deep underground, so no template can offer sky access. Both tests now build their machine in open air above their own test area and pin the weather. The blocked variant waits for the light engine before covering the machine, and both wipe the spot first, since only the structure itself is cleaned up between runs.
* New `ChanceLogicTest` locks the overflow fixes: both cases fail on the old math (70504 outputs instead of 500000, and parallels wrapping to 0).
